### PR TITLE
added missing dependencies to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## VitaSDK. How to build.
 
 ```
-apt-get install cmake git build-essential autoconf texinfo
+apt-get install cmake git build-essential autoconf texinfo bison flex
 ```
 
 ### Native compilation.


### PR DESCRIPTION
Tested from a bare-ish version of xenial. I needed install `bison` and `flex` for the build to succeed.
